### PR TITLE
Workaround: content source load order affects language list used for …

### DIFF
--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -4,19 +4,19 @@ site:
 
 content:
   sources:
-    - url: https://github.com/rancher/product-docs-playbook.git
+    - url: https://github.com/rancher/product-docs-playbook.git # en
       branches: [main]
-    - url: https://github.com/rancher/fleet-product-docs.git
+    - url: https://github.com/rancher/fleet-product-docs.git # en
       branches: [main]
       start_paths: [versions/v0.10, versions/v0.9]
-    - url: https://github.com/rancher/k3s-product-docs
-      branches: [main]
-      start_path: versions/latest
-    - url: https://github.com/rancher/kubewarden-product-docs.git
+    - url: https://github.com/rancher/kubewarden-product-docs.git # en
       branches: [main]
       start_paths: [docs/next, docs/version-*]
-    - url: https://github.com/rancher/longhorn-product-docs.git
+    - url: https://github.com/rancher/longhorn-product-docs.git # en
       branches: [1.8.0, 1.7.1, 1.7.0, 1.6.3, 1.6.2, 1.6.1, 1.6.0, 1.5.6, 1.5.5]
+    - url: https://github.com/rancher/k3s-product-docs # en, ja, ko, zh
+      branches: [main]
+      start_path: versions/latest
 ui:
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true


### PR DESCRIPTION
…subsequent content sources

Current case:
- K3s is the only content source for multiple languages
- Kubewarden and Longhorn are load after K3s and inherit K3s' language list.

Workaround:
- Load K3s last