### PR TITLE
Updating Playbooks and Articles Listing - v0.12 CAPI Docs

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -1,5 +1,5 @@
 -------------------------------
-Fleet
+SUSE® Rancher Prime Continuous Delivery
 0.10: 2024-07-17
 0.9: 2023-11-07
  * Overview
@@ -30,26 +30,26 @@ Fleet
     * /product-docs-playbook/fleet-documentation/v0.9/en/changelogs/changelogs/v0.9.0.html
     * This section covers release information.
 -------------------------------
-Turtles
+SUSE® Rancher Prime Cluster API
+0.12: 2024-09-26
 0.11: 2024-08-22
-0.10: 2024-07-29
  * Getting Started
-    * /product-docs-playbook/turtles-documentation/v0.11/en/index.html
-    * This section covers setup, installation, uninstalling, and initial cluster examples of Turtles.
+    * /product-docs-playbook/turtles-documentation/v0.12/en/index.html
+    * This section covers setup, installation, uninstalling, and initial cluster examples of SUSE® Rancher Prime Cluster API.
  * Reference Guides
-    * /product-docs-playbook/turtles-documentation/v0.11/en/reference-guides/architecture/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.12/en/reference-guides/architecture/intro.html
     * This section covers Turtles architecture components, Helm chart configuration, CAPI providers, and testing.
  * Tasks
-    * /product-docs-playbook/turtles-documentation/v0.11/en/tasks/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.12/en/tasks/intro.html
     * This section covers additional operational tasks such as installing using the CAPIProvider resource, maintenance tasks, and provider certification.
  * Developer Guide
-    * /product-docs-playbook/turtles-documentation/v0.11/en/developer-guide/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.12/en/developer-guide/intro.html
     * This section covers information on setting up a development environment.
  * Reference
-    * /product-docs-playbook/turtles-documentation/v0.11/en/reference/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.12/en/reference/intro.html
     * This section offers guidelines on how to get involved and a term glossary. 
  * Security
-    * /product-docs-playbook/turtles-documentation/v0.11/en/security/slsa.html
+    * /product-docs-playbook/turtles-documentation/v0.12/en/security/slsa.html
     * This section covers Turtles SLSA security compliance.
 -------------------------------
 SUSE® Rancher Prime Policy Manager

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -15,7 +15,7 @@ content:
       start_paths: [docs/*]
     - url: ../turtles-product-docs # en
       branches: [main]
-      start_paths: [versions/v0.11, versions/v0.10]
+      start_paths: [versions/v0.12, versions/v0.11]
     - url: ../kubewarden-product-docs # en
       branches: [main]
       start_paths: [shared, docs/next, docs/version-*]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -15,7 +15,7 @@ content:
       start_paths: [docs/*]
     - url: https://github.com/rancher/turtles-product-docs.git # en
       branches: [main]
-      start_paths: [versions/v0.11, versions/v0.10]
+      start_paths: [versions/v0.12, versions/v0.11]
     - url: https://github.com/rancher/kubewarden-product-docs.git # en
       branches: [main]
       start_paths: [shared, docs/next, docs/version-*]


### PR DESCRIPTION
Updating the remote and local Product playbook files to account for v0.12 of CAPI, and also updating the articles listing page to point to v0.12 versions/updating to branded naming convention.