### PR TITLE
Set site.url

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -1,6 +1,7 @@
 site:
   title: Rancher product documentation
   start_page: latest@rancher-manager:en:about-rancher/what-is-rancher.adoc
+  url: https://documentation.suse.com/cloudnative
 
 content:
   sources:

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -1,6 +1,7 @@
 site:
   title: Rancher product documentation
   start_page: latest@rancher-manager:en:about-rancher/what-is-rancher.adoc
+  url: https://documentation.suse.com/cloudnative
 
 content:
   sources:


### PR DESCRIPTION
Some [features](https://docs.antora.org/antora/latest/playbook/site-url/#when-should-the-site-url-be-set) aren't enabled unless `site.url` is set. One such feature that we want enabled is the auto-generated canonical URL which helps with SEO and for parity with our community docs.