### PR TITLE
Adding v0.14/v0.15 CAPI Docs

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -31,26 +31,28 @@ SUSE® Rancher Prime Continuous Delivery
     * This section covers release information.
 -------------------------------
 SUSE® Rancher Prime Cluster API
+0.15: 2024-12-19
+0.14: 2024-12-02
 0.13: 2024-11-08
 0.12: 2024-09-26
 0.11: 2024-08-22
  * Getting Started
-    * /product-docs-playbook/turtles-documentation/v0.13/en/index.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/index.html
     * This section covers setup, installation, uninstalling, and initial cluster examples of SUSE® Rancher Prime Cluster API.
  * Reference Guides
-    * /product-docs-playbook/turtles-documentation/v0.13/en/reference-guides/architecture/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/reference-guides/architecture/intro.html
     * This section covers Turtles architecture components, Helm chart configuration, CAPI providers, and testing.
  * Tasks
-    * /product-docs-playbook/turtles-documentation/v0.13/en/tasks/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/tasks/intro.html
     * This section covers additional operational tasks such as installing using the CAPIProvider resource, maintenance tasks, and provider certification.
  * Developer Guide
-    * /product-docs-playbook/turtles-documentation/v0.13/en/developer-guide/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/developer-guide/intro.html
     * This section covers information on setting up a development environment.
  * Reference
-    * /product-docs-playbook/turtles-documentation/v0.13/en/reference/intro.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/reference/intro.html
     * This section offers guidelines on how to get involved and a term glossary. 
  * Security
-    * /product-docs-playbook/turtles-documentation/v0.13/en/security/slsa.html
+    * /product-docs-playbook/turtles-documentation/v0.15/en/security/slsa.html
     * This section covers Turtles SLSA security compliance.
 -------------------------------
 SUSE® Rancher Prime Policy Manager

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: ../turtles-product-docs # en
       branches: [main]
-      start_paths: [versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: ../kubewarden-product-docs # en
       branches: [main]
       start_paths: [shared, docs/next, docs/version-*]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: https://github.com/rancher/turtles-product-docs.git # en
       branches: [main]
-      start_paths: [versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: https://github.com/rancher/kubewarden-product-docs.git # en
       branches: [main]
       start_paths: [shared, docs/next, docs/version-*]


### PR DESCRIPTION
Updating the product docs playbook local/remote YAML files with latest CAPI versions. Also updating the articles-listing.conf file with v0.14/v0.15 information.

NOTE:
This should only be merged after the PR adding v0.14/v0.15 CAPI docs versions is merged (https://github.com/rancher/turtles-product-docs/pull/31).