### PR TITLE
Update Articles Listing - SUSE Security

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -308,7 +308,7 @@ SUSE® Security
    * This section provides an overview of the requirements, architecture, components, and features of SUSE® Security.
 * Operational Tasks
    * product-docs-playbook/neuvector-product-docs/5.4/en/users.html
-   * This section covers operational tasks such as user management, certificates management and automation.
+   * This section covers operational tasks such as user management, certificates management, and automation.
 * Deploying SUSE® Security
    * product-docs-playbook/neuvector-product-docs/5.4/en/rancher.html
    * This section covers deployment methods, including SUSE® Rancher Manager, Kubernetes, OpenShift, air-gapped, and Docker.

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -297,7 +297,7 @@ SUSE® Rancher Manager
 SUSE® Security
 5.4: 2024-09-19
 5.3: 2024-01-31
-* SUSE® Security overview
+* SUSE® Security Overview
    * product-docs-playbook/neuvector-product-docs/5.4/en/overview.html
    * Overview of SUSE® Security, including its features, benefits, and use cases.
 * SUSE® Security Release Notes

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -300,40 +300,43 @@ SUSE® Security
 * SUSE® Security overview
    * product-docs-playbook/neuvector-product-docs/5.4/en/overview.html
    * Overview of SUSE® Security, including its features, benefits, and use cases.
+* SUSE® Security Release Notes
+   * product-docs-playbook/neuvector-product-docs/5.4/en/5x.html
+   * This section covers the SUSE® Security 5.x release notes.
 * Understanding SUSE® Security
    * product-docs-playbook/neuvector-product-docs/5.4/en/requirements.html
    * This section provides an overview of the requirements, architecture, components, and features of SUSE® Security.
-* Operational tasks
+* Operational Tasks
    * product-docs-playbook/neuvector-product-docs/5.4/en/users.html
    * This section covers operational tasks such as users management, certificates management and automation.
 * Deploying SUSE® Security
    * product-docs-playbook/neuvector-product-docs/5.4/en/rancher.html
    * This section covers deployment methods, including SUSE® Rancher Manager, Kubernetes, OpenShift, air-gapped, and Docker.
-* SUSE® Security interface
+* SUSE® Security Interface
    * product-docs-playbook/neuvector-product-docs/5.4/en/navigation.html
    * This section covers the SUSE® Security interface, including navigation, multi-cluster management, modes, reporting, and customizing the UI.
 * Security Policy
    * product-docs-playbook/neuvector-product-docs/5.4/en/customcompliance.html
    * This section covers security policy, including network rules, DLP & WAF sensors, network threat signatures, custom compliance checks, and more.
-* Admission controls
+* Admission Controls
    * product-docs-playbook/neuvector-product-docs/5.4/en/admission.html
    * This section covers admission controls, including Sigstore Cosign, and configuration assessment for Kubernetes resources.
-* Custom resource definitions
+* Custom Resource Definitions
    * product-docs-playbook/neuvector-product-docs/5.4/en/usingcrd.html
    * This section covers the custom resource definitions (CRD) management.
-* Scanning & compliance
+* Scanning & Compliance
    * product-docs-playbook/neuvector-product-docs/5.4/en/scanning.html
    * This section covers scanning, vulnerabilities, and compliance.
-* Registry scanning
+* Registry Scanning
    * product-docs-playbook/neuvector-product-docs/5.4/en/registry-scanning-configuration.html
    * This section covers registry scanning, including Harbor, Amazon ECR, and Google GCR.
-* Build phase image scanning
+* Build Phase Image Scanning
    * product-docs-playbook/neuvector-product-docs/5.4/en/build-image-scanning.html
    * This section covers build phase image scanning, including Jenkins, Bamboo, CircleCI, Azure DevOps, Gitlab, and GitHub.
 * Integration
    * product-docs-playbook/neuvector-product-docs/5.4/en/integration.html
    * This section containes a number of ways how to integrate SUSE® Security, including a REST API, CLI, SYSLOG, RBACs, SAML, LDAP, and webhooks
-* SUSE Security Performance Tuninig [Prime-only]
+* SUSE Security Performance Tuning [Prime-only]
    * prime-docs/latest/en/suse-security/neuvector-performance-tuning.html
    * The SUSE Security Performance Tuning Guide offers insights on reducing resource consumption by adjusting certain security functions, network policies etc, and provides guidance on resources monitoring.
 -------------------------------

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -308,13 +308,13 @@ SUSE® Security
    * This section provides an overview of the requirements, architecture, components, and features of SUSE® Security.
 * Operational Tasks
    * product-docs-playbook/neuvector-product-docs/5.4/en/users.html
-   * This section covers operational tasks such as users management, certificates management and automation.
+   * This section covers operational tasks such as user management, certificates management and automation.
 * Deploying SUSE® Security
    * product-docs-playbook/neuvector-product-docs/5.4/en/rancher.html
    * This section covers deployment methods, including SUSE® Rancher Manager, Kubernetes, OpenShift, air-gapped, and Docker.
 * SUSE® Security Interface
    * product-docs-playbook/neuvector-product-docs/5.4/en/navigation.html
-   * This section covers the SUSE® Security interface, including navigation, multi-cluster management, modes, reporting, and customizing the UI.
+   * This section covers the SUSE® Security interface, including navigation, multi-cluster management, modes, reporting, and UI customization.
 * Security Policy
    * product-docs-playbook/neuvector-product-docs/5.4/en/customcompliance.html
    * This section covers security policy, including network rules, DLP & WAF sensors, network threat signatures, custom compliance checks, and more.
@@ -335,10 +335,10 @@ SUSE® Security
    * This section covers build phase image scanning, including Jenkins, Bamboo, CircleCI, Azure DevOps, Gitlab, and GitHub.
 * Integration
    * product-docs-playbook/neuvector-product-docs/5.4/en/integration.html
-   * This section containes a number of ways how to integrate SUSE® Security, including a REST API, CLI, SYSLOG, RBACs, SAML, LDAP, and webhooks
+   * This section contains several methods of integrating SUSE® Security, which include REST API, CLI, SYSLOG, RBACs, SAML, LDAP, and webhooks.
 * SUSE Security Performance Tuning [Prime-only]
    * prime-docs/latest/en/suse-security/neuvector-performance-tuning.html
-   * The SUSE Security Performance Tuning Guide offers insights on reducing resource consumption by adjusting certain security functions, network policies etc, and provides guidance on resources monitoring.
+   * The SUSE Security Performance Tuning Guide offers insights on reducing resource consumption by adjusting certain security functions, network policies, etc., and provides guidance on resource monitoring.
 -------------------------------
 SUSE® Rancher Prime OS Manager
 1.6: 2024-09-19


### PR DESCRIPTION
Updating the articles listing page with added "SUSE Security 5.x Release Notes" section and updating headers to titlecase.