### PR TITLE
Update SUSE Storage and SUSE Virtualization links

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -92,36 +92,37 @@ SUSE® Rancher Prime Policy Manager
     * Common tasks with for Kubewarden.
 -------------------------------
 SUSE® Storage
+1.8.0: 2025-01-22
 1.7.0: 2024-08-20
 * Architecture and Concepts
-   * /product-docs-playbook/storage/1.7.0/en/introduction/concepts.html
+   * /product-docs-playbook/storage/1.8.0/en/introduction/concepts.html
    * Descriptions of the overall design, key system components, and storage features such as volumes and backups.
 * Installation and Setup Requirements
-   * /product-docs-playbook/storage/1.7.0/en/installation-setup/requirements.html
+   * /product-docs-playbook/storage/1.8.0/en/installation-setup/requirements.html
    * Installation requirements, general setup instructions, and links to topics that contain distribution-specific information.
 * Upgrades
-   * /product-docs-playbook/storage/1.7.0/en/upgrades/upgrades.html
+   * /product-docs-playbook/storage/1.8.0/en/upgrades/upgrades.html
    * Supported upgrade paths and high-level instructions for upgrading SUSE® Storage.
 * System Access
-   * /product-docs-playbook/storage/1.7.0/en/longhorn-system/system-access/system-access.html
+   * /product-docs-playbook/storage/1.8.0/en/longhorn-system/system-access/system-access.html
    * Requirements and tools for accessing the SUSE® Storage system.
 * Settings
-   * /product-docs-playbook/storage/1.7.0/en/longhorn-system/settings.html
+   * /product-docs-playbook/storage/1.8.0/en/longhorn-system/settings.html
    * Settings that you can configure according to your cluster environment and specific requirements.
 * Multiple Disks
-   * /product-docs-playbook/storage/1.7.0/en/nodes/multiple-disks.html
+   * /product-docs-playbook/storage/1.8.0/en/nodes/multiple-disks.html
    * Information about storing volume data on multiple disks.
 * Volume Creation
-   * /product-docs-playbook/storage/1.7.0/en/volumes/create-volumes.html
+   * /product-docs-playbook/storage/1.8.0/en/volumes/create-volumes.html
    * Methods of creating volumes and issues that may cause volume creation to fail.
 * Volume Snapshots and Backups
-   * /product-docs-playbook/storage/1.7.0/en/snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.html
+   * /product-docs-playbook/storage/1.8.0/en/snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.html
    * Overview of volume snapshots and backups, and links to topics that explain related concepts and procedures.
 * Data Errors
-   * /product-docs-playbook/storage/1.7.0/en/data-integrity-recovery/data-recovery/recover-from-data-errors.html
+   * /product-docs-playbook/storage/1.8.0/en/data-integrity-recovery/data-recovery/recover-from-data-errors.html
    * Methods of identifying and recovering from data errors.
 * Monitoring Using Prometheus and Grafana
-   * /product-docs-playbook/storage/1.7.0/en/observability/configure-prometheus-grafana.html
+   * /product-docs-playbook/storage/1.8.0/en/observability/configure-prometheus-grafana.html
    * How to configure tools for data collection, alert management, and storage metric visualization.
 -------------------------------
 SUSE® Rancher Prime K3s

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -212,40 +212,40 @@ latest: 2024-09-13
    * This document recommends how to plan for and implement replatforming from Rancher-managed RKE clusters to Rancher-managed RKE2 cluster.
 -------------------------------
 SUSE® Virtualization
-v1.4: 2024-11-28
-v1.3: 2024-03-15
+v1.4.0: 2024-11-28
+v1.3.0: 2024-03-15
 *  An introduction to SUSE® Virtualization
-   * /product-docs-playbook/harvester/v1.3/en/introduction/index.html
+   * /product-docs-playbook/virtualization/v1.4/en/introduction/overview.html
    * An introduction to SUSE® Virtualization, a modern, open, interoperable, hyperconverged infrastructure (HCI) solution built on Kubernetes.
 *  Installation and Setup
-   * /product-docs-playbook/harvester/v1.3/en/installation-setup/requirements.html
+   * /product-docs-playbook/virtualization/v1.4/en/installation-setup/requirements.html
    * This section contains the prerequisites, installation methods, configuration options, and explains how to use SUSE® Virtualization in an air gapped environment.
 *  Upgrades
-   * /product-docs-playbook/harvester/v1.3/en/upgrades/upgrades.html
+   * /product-docs-playbook/virtualization/v1.4/en/upgrades/upgrades.html
    * This sections covers how to upgrade SUSE® Virtualization and important changes between versions.
 *  Hosts
-   * /product-docs-playbook/harvester/v1.3/en/hosts/hosts.html
+   * /product-docs-playbook/virtualization/v1.4/en/hosts/hosts.html
    * This section covers how to manage nodes in a SUSE® Virtualization cluster.
 *  Virtual Machines
-   * /product-docs-playbook/harvester/v1.3/en/virtual-machines/vm-images/upload-image.html
+   * /product-docs-playbook/virtualization/v1.4/en/virtual-machines/create-vm.html
    * This section covers how to create, manage, and backup virtual machines.
 *  Storage
-   * /product-docs-playbook/harvester/v1.3/en/storage/volumes/create-volume.html
+   * /product-docs-playbook/virtualization/v1.4/en/storage/volumes/create-volume.html
    * This section covers how to create and manage volumes and storage classes.
 *  Networking
-   * /product-docs-playbook/harvester/v1.3/en/networking/cluster-network.html
+   * /product-docs-playbook/virtualization/v1.4/en/networking/cluster-network.html
    * This section covers SUSE® Virtualization networking-related topics such as the cluster network, VM network, load balancer, IP Pool, and storage network. 
 *  Observability
-   * /product-docs-playbook/harvester/v1.3/en/observability/harvester-logging.html
+   * /product-docs-playbook/virtualization/v1.4/en/observability/logging.html
    * This section covers observability topics such logging and monitoring.
 *  Add-ons
-   * /product-docs-playbook/harvester/v1.3/en/add-ons/add-ons.html
+   * /product-docs-playbook/virtualization/v1.4/en/add-ons/add-ons.html
    * This section provides information about add-ons such as Harvester Seeder, NVIDIA Driver Toolkit, and rancher-vcluster. 
 *  Integrations
-   * /product-docs-playbook/harvester/v1.3/en/integrations/rancher/rancher-integration.html
+   * /product-docs-playbook/virtualization/v1.4/en/integrations/rancher/rancher-integration.html
    * This section provides information about how to integrate SUSE® Rancher Prime with SUSE® Virtualization.
 *  Troubleshooting
-   * /product-docs-playbook/harvester/v1.3/en/troubleshooting/faq.html
+   * /product-docs-playbook/virtualization/v1.4/en/troubleshooting/faq.html
    * This section covers general troubleshooting tips.
 -------------------------------
 SUSE® Rancher Manager


### PR DESCRIPTION
Changes:
- SUSE Storage: Add v1.8.0 release date; update version in links
- SUSE Virtualization: Update version in links; replace instances of 'harvester' with 'virtualization' in links