### PR TITLE
Adding v0.12 Fleet

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -1,38 +1,33 @@
 -------------------------------
 SUSE® Rancher Prime Continuous Delivery
-0.11: 2025-11-10
+0.12: 2025-03-24
+0.11: 2024-11-10
 0.10: 2024-07-17
 0.9: 2023-11-07
  * Overview
-   * /product-docs-playbook/fleet-documentation/v0.11/en/index.html
+   * /product-docs-playbook/continuous-delivery/v0.12/en/index.html
    * This section provides an overview of continuous delivery and deployment management.
  * Tutorials
-   * /product-docs-playbook/fleet-documentation/v0.11/en/quickstart.html
+   * /product-docs-playbook/continuous-delivery/v0.12/en/quickstart.html
    * This section covers a quickstart on installation, creating a deployment, and uninstalling.
  * Explanations
-    * /product-docs-playbook/fleet-documentation/v0.11/en/architecture.html
+    * /product-docs-playbook/continuous-delivery/v0.12/en/architecture.html
     * This section describes architecture, core concepts, and resources involved.
  * How-tos for Operators
-    * /product-docs-playbook/fleet-documentation/v0.11/en/installation.html
+    * /product-docs-playbook/continuous-delivery/v0.12/en/installation.html
     * This section covers guides and installation details for operators.
  * How-tos for Users
-    * /product-docs-playbook/fleet-documentation/v0.11/en/gitrepo-add.html
+    * /product-docs-playbook/continuous-delivery/v0.12/en/gitrepo-add.html
     * This section covers guides for users.
  * Reference
-    * /product-docs-playbook/fleet-documentation/v0.11/en/cli/fleet-agent/fleet-agent.html
+    * /product-docs-playbook/continuous-delivery/v0.12/en/cli/fleet-agent/fleet-agent.html
     * This section covers general reference material and CLI reference information.
  * Troubleshooting
-    * /product-docs-playbook/fleet-documentation/v0.11/en/troubleshooting.html
+    * /product-docs-playbook/continuous-delivery/v0.12/en/troubleshooting.html
     * This section covers general troubleshooting tips.
- * 0.11: Changelog
-    * /product-docs-playbook/fleet-documentation/v0.11/en/v0.11.1.html
-    * This section covers release information.
- * 0.10: Changelog
-    * /product-docs-playbook/fleet-documentation/v0.10/en/v0.10.0.html
-    * This section covers release information.
- * 0.9: Changelog
-    * /product-docs-playbook/fleet-documentation/v0.9/en/changelogs/changelogs/v0.9.0.html
-    * This section covers release information.
+ * Changelog
+    * /product-docs-playbook/continuous-delivery/v0.12/en/v0.12.0.html
+    * This section covers release notes.
 -------------------------------
 SUSE® Rancher Prime Cluster API
 0.17: 2025-02-27

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -7,7 +7,7 @@ content:
   sources:
     - url: ../fleet-product-docs # en
       branches: [main]
-      start_paths: [versions/v0.11, versions/v0.10, versions/v0.9]
+      start_paths: [versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
     - url: ../neuvector-product-docs # en
       branches: [main]
       start_paths: [docs/*]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -7,7 +7,7 @@ content:
   sources:
     - url: https://github.com/rancher/fleet-product-docs.git # en
       branches: [main]
-      start_paths: [versions/v0.11, versions/v0.10, versions/v0.9]
+      start_paths: [versions/v0.12, versions/v0.11, versions/v0.10, versions/v0.9]
     - url: https://github.com/rancher/neuvector-product-docs.git # en
       branches: [main]
       start_paths: [docs/*]


### PR DESCRIPTION
Depends on https://github.com/rancher/fleet-product-docs/pull/39.

Updating the playbook files with v0.12 Fleet docs and updating the articles listing page.