### PR TITLE
Updated SUSE Storage version in all necessary files

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -105,34 +105,34 @@ SUSE® Storage
 1.8.0: 2025-01-22
 1.7.0: 2024-08-20
 * Architecture and Concepts
-   * /product-docs-playbook/storage/1.9.0/en/introduction/concepts.html
+   * /product-docs-playbook/storage/1.9/en/introduction/concepts.html
    * Descriptions of the overall design, key system components, and storage features such as volumes and backups.
 * Installation and Setup Requirements
-   * /product-docs-playbook/storage/1.9.0/en/installation-setup/requirements.html
+   * /product-docs-playbook/storage/1.9/en/installation-setup/requirements.html
    * Installation requirements, general setup instructions, and links to topics that contain distribution-specific information.
 * Upgrades
-   * /product-docs-playbook/storage/1.9.0/en/upgrades/upgrades.html
+   * /product-docs-playbook/storage/1.9/en/upgrades/upgrades.html
    * Supported upgrade paths and high-level instructions for upgrading SUSE® Storage.
 * System Access
-   * /product-docs-playbook/storage/1.9.0/en/longhorn-system/system-access/system-access.html
+   * /product-docs-playbook/storage/1.9/en/longhorn-system/system-access/system-access.html
    * Requirements and tools for accessing the SUSE® Storage system.
 * Settings
-   * /product-docs-playbook/storage/1.9.0/en/longhorn-system/settings.html
+   * /product-docs-playbook/storage/1.9/en/longhorn-system/settings.html
    * Settings that you can configure according to your cluster environment and specific requirements.
 * Multiple Disks
-   * /product-docs-playbook/storage/1.9.0/en/nodes/multiple-disks.html
+   * /product-docs-playbook/storage/1.9/en/nodes/multiple-disks.html
    * Information about storing volume data on multiple disks.
 * Volume Creation
-   * /product-docs-playbook/storage/1.9.0/en/volumes/create-volumes.html
+   * /product-docs-playbook/storage/1.9/en/volumes/create-volumes.html
    * Methods of creating volumes and issues that may cause volume creation to fail.
 * Volume Snapshots and Backups
-   * /product-docs-playbook/storage/1.9.0/en/snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.html
+   * /product-docs-playbook/storage/1.9/en/snapshots-backups/volume-snapshots-backups/volume-snapshots-backups.html
    * Overview of volume snapshots and backups, and links to topics that explain related concepts and procedures.
 * Data Errors
-   * /product-docs-playbook/storage/1.9.0/en/data-integrity-recovery/data-recovery/recover-from-data-errors.html
+   * /product-docs-playbook/storage/1.9/en/data-integrity-recovery/data-recovery/recover-from-data-errors.html
    * Methods of identifying and recovering from data errors.
 * Monitoring Using Prometheus and Grafana
-   * /product-docs-playbook/storage/1.9.0/en/observability/configure-prometheus-grafana.html
+   * /product-docs-playbook/storage/1.9/en/observability/configure-prometheus-grafana.html
    * How to configure tools for data collection, alert management, and storage metric visualization.
 -------------------------------
 SUSE® Rancher Prime K3s

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -22,7 +22,7 @@ content:
       start_paths: [shared, docs/version-*]
     - url: ../longhorn-product-docs # en
       branches: [main]
-      start_paths: [shared, docs/version-1.7.0, docs/version-1.8.0, docs/version-1.9.0, docs/version-1.10.0]
+      start_paths: [shared, docs/version-1.7, docs/version-1.8, docs/version-1.9, docs/version-1.10]
     - url: ../harvester-product-docs # en
       branches: [main]
       start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -22,7 +22,7 @@ content:
       start_paths: [shared, docs/version-*]
     - url: https://github.com/rancher/longhorn-product-docs.git # en
       branches: [main]
-      start_paths: [shared, docs/version-1.7.0, docs/version-1.8.0, docs/version-1.9.0, docs/version-1.10.0]
+      start_paths: [shared, docs/version-1.7, docs/version-1.8, docs/version-1.9, docs/version-1.10]
     - url: https://github.com/rancher/harvester-product-docs # en
       branches: [main]
       start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]


### PR DESCRIPTION
Initially we were only targeting feature releases and updates in documentation. Changed the version to group all the patch release of under the correct feature releases.

Version Changed:
- 1.7.0 to 1.7 (It will contain all the released versions of 1.7.x)
- 1.8.0 to 1.8 (It will contain all the released versions of 1.8.x)
- 1.9.0 to 1.9 (It will contain all the released versions of 1.9.x)
- 1.10.0 to 1.10 (It will contain all the released versions of 1.10.x)

Related Issue: [Issue #234](https://github.com/rancher/longhorn-product-docs/issues/234)