### PR TITLE
Adding CAPI v0.22 docs

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -30,6 +30,7 @@ SUSE® Rancher Prime Continuous Delivery
     * This section covers release notes.
 -------------------------------
 SUSE® Rancher Prime Cluster API
+0.22: 2025-07-29
 0.21: 2025-06-30
 0.20: 2025-05-29
 0.19: 2025-04-29
@@ -42,31 +43,31 @@ SUSE® Rancher Prime Cluster API
 0.12: 2024-09-26
 0.11: 2024-08-22
  * Tutorials
-    * /product-docs-playbook/cluster-api/v0.21/en/tutorials/quickstart.html
+    * /product-docs-playbook/cluster-api/v0.22/en/tutorials/quickstart.html
     * This section covers setup, installation, uninstalling, and initial cluster examples of SUSE® Rancher Prime Cluster API.
  * Reference
-    * /product-docs-playbook/cluster-api/v0.21/en/reference/architecture.html
+    * /product-docs-playbook/cluster-api/v0.22/en/reference/architecture.html
     * This section covers Turtles architecture components, Helm chart configuration, CAPI providers, and testing.
  * User Guide
-    * /product-docs-playbook/cluster-api/v0.21/en/user/clusters.html
+    * /product-docs-playbook/cluster-api/v0.22/en/user/clusters.html
     * This section provides user guides such as provisioning a CAPI cluster.
  * Operator Guide
-    * /product-docs-playbook/cluster-api/v0.21/en/operator/manual.html
+    * /product-docs-playbook/cluster-api/v0.22/en/operator/manual.html
     * This section provides operator information on advanced maintenance tasks such as customizing your CAPI installation.
  * Developer Guide
-    * /product-docs-playbook/cluster-api/v0.21/en/developer/development.html
+    * /product-docs-playbook/cluster-api/v0.22/en/developer/development.html
     * This section offers guidelines on how to get involved and development setup.
  * Security
-    * /product-docs-playbook/cluster-api/v0.21/en/security/slsa.html
+    * /product-docs-playbook/cluster-api/v0.22/en/security/slsa.html
     * This section covers CAPI SLSA security compliance.
 * Create a SUSE Linux Micro VM Template in vSphere (Deploy Using CAPV & CAPRKE2) [Prime-only]
    * /rancherprime/latest/en/suse-rancher-prime-capi/vsphere-vm-template.html
    * This guide describes how to create a VM template in VMware vSphere using a SUSE Linux .vmdk disk image. The template is useful for deploying Kubernetes clusters with SUSE Linux Micro using Cluster API Provider vSphere (CAPV) together with Cluster API Provider RKE2 (CAPRKE2) in the SUSE Rancher Prime Cluster API (CAPI).
  * Troubleshooting Guide
-    * /product-docs-playbook/cluster-api/v0.21/en/troubleshooting/troubleshooting.html
+    * /product-docs-playbook/cluster-api/v0.22/en/troubleshooting/troubleshooting.html
     * This section covers basic troubleshooting related to Rancher Turtles, Cluster API (CAPI), and CAPI providers.
  * Release Notes
-    * /product-docs-playbook/cluster-api/v0.21/en/changelogs/index.html
+    * /product-docs-playbook/cluster-api/v0.22/en/changelogs/index.html
     * This section covers CAPI release notes.
 -------------------------------
 SUSE® Rancher Prime Admission Policy Manager

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: ../turtles-product-docs # en
       branches: [main]
-      start_paths: [versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: ../kubewarden-product-docs # en
       branches: [HEAD]
       start_paths: [shared, docs/version-*]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: https://github.com/rancher/turtles-product-docs.git # en
       branches: [main]
-      start_paths: [versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: https://github.com/rancher/kubewarden-product-docs.git # en
       branches: [main]
       start_paths: [shared, docs/version-*]


### PR DESCRIPTION
Adding v0.22 CAPI to articles listing configuration and playbook files.
Dependent on https://github.com/rancher/turtles-product-docs/pull/54.