### PR TITLE
Revert "Don't deploy to GitHub pages"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,3 +57,6 @@ jobs:
           git add .
           git commit -m "$COMMIT_MESSAGE"
           git push --force origin gh-pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Reverts rancher/product-docs-playbook#158 as the team still has dependencies on this.