### PR TITLE
Removed 1.7 (deprecated) for redirects

### DIFF
--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -25,7 +25,7 @@ content:
       start_paths: [shared, docs/latest, docs/version-*]
     - url: https://github.com/rancher/longhorn-product-docs.git # en
       branches: [main]
-      start_paths: [shared, docs/version-1.7, docs/version-1.8, docs/version-1.9, docs/version-1.10]
+      start_paths: [shared, docs/version-1.8, docs/version-1.9, docs/version-1.10]
     - url: https://github.com/rancher/harvester-product-docs # en
       branches: [main]
       start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]


### PR DESCRIPTION
Removed SUSE Storage v1.7 from build so that it does not appear on gh-pages.