### PR TITLE
Removed v1.7 from remote playbook

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -25,7 +25,7 @@ content:
       start_paths: [shared, docs/latest, docs/version-*]
     - url: ../longhorn-product-docs # en
       branches: [main]
-      start_paths: [shared, docs/version-1.7, docs/version-1.8, docs/version-1.9, docs/version-1.10]
+      start_paths: [shared, docs/version-1.8, docs/version-1.9, docs/version-1.10]
     - url: ../harvester-product-docs # en
       branches: [main]
       start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]


### PR DESCRIPTION
I removed v1.7 from local playbook in [this PR](https://github.com/rancher/product-docs-playbook/pull/160).