### PR TITLE
Remove v1.3 from SUSE Virtualization start_paths

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -35,7 +35,7 @@ content:
       start_paths: [shared, docs/latest, docs/version-1.8, docs/version-1.9, docs/version-1.10, docs/version-1.11]
     - url: ../harvester-product-docs # en
       branches: [main]
-      start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]
+      start_paths: [versions/v1.6, versions/v1.5, versions/v1.4]
     - url: ../rancher-product-docs # en, zh
       start_paths: [shared, versions/latest, versions/v2.12, versions/v2.11, versions/v2.10, versions/v2.9, versions/v2.8]
     - url: ../rke2-product-docs # en, zh

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -35,7 +35,7 @@ content:
       start_paths: [shared, docs/latest, docs/version-1.8, docs/version-1.9, docs/version-1.10, docs/version-1.11]
     - url: https://github.com/rancher/harvester-product-docs # en
       branches: [main]
-      start_paths: [versions/v1.6, versions/v1.5, versions/v1.4, versions/v1.3]
+      start_paths: [versions/v1.6, versions/v1.5, versions/v1.4]
     - url: https://github.com/rancher/rancher-product-docs # en ,zh
       branches: [main]
       start_paths: [shared, versions/latest, versions/v2.12, versions/v2.11, versions/v2.10, versions/v2.9, versions/v2.8]


### PR DESCRIPTION
References: https://github.com/rancher/product-docs-playbook/pull/160 and https://github.com/rancher/product-docs-playbook/pull/162

Scope: v1.3
- `product-docs-playbook-local.yml`
- `product-docs-playbook-remote.yml`