### PR TITLE
Renamed the page titles in the "article-listing.conf" file.

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -239,10 +239,10 @@ latest: 2025-11-18
    * Welcome to the SUSE® Virtual Clusters.
 * Quick Start: Installation and cluster creation via the UI [Prime-only]
    */prime-docs/latest/en/suse-virtual-cluster/quickstart.html
-   * This section covers installing SUSE Virtual Clusters and using it to create K3k virtual clusters.
+   * This section covers installing SUSE Virtual Clusters and using it to create and manage virtual clusters.
 * Architecture
    * /product-docs-playbook/suse-virtual-clusters/latest/en/architecture.html
-   * This section covers the two modes for deploying virtual clusters, K3k components, and VirtualClusterPolicy.
+   * This section covers the two modes for deploying virtual clusters.
 * Advanced Usage
    * /product-docs-playbook/suse-virtual-clusters/latest/en/advanced-usage.html
    * This section covers detailed use cases and explanations of the Cluster resource fields for customization.
@@ -251,7 +251,7 @@ latest: 2025-11-18
    * This section covers the concepts of a VirtualClusterPolicy.
 * Add-ons
    * /product-docs-playbook/suse-virtual-clusters/latest/en/addons.html
-   * This document provides information on provisioning the K3k cluster using the add-ons feature.
+   * This document provides information on provisioning the SUSE virtual cluster using the add-ons feature.
 * How-tos for User
    * /product-docs-playbook/suse-virtual-clusters/latest/en/how-tos-for-user/create-virtual-clusters.html
    * This section covers guides for users.
@@ -263,13 +263,13 @@ latest: 2025-11-18
    * This section covers reference information for custom resource definitions (CRD) material and the CLI.
 * Troubleshooting
    * /product-docs-playbook/suse-virtual-clusters/latest/en/how-tos-for-user/troubleshooting.html
-   * This section contains common troubleshooting steps for K3K virtual clusters.
+   * This section contains common troubleshooting steps for SUSE virtual clusters.
 * What is SUSE Virtual Clusters [Prime-only]
    * /prime-docs/latest/en/suse-virtual-cluster/what-is-suse-vc.html
    * This provides an overview of the SUSE® Virtual Clusters.
 * Creating a Virtual Cluster with Custom CAs Using cert-manager [Prime-only]
    * /prime-docs/latest/en/suse-virtual-cluster/how-to-guides/cert-manager-create-custom-cas.html
-   * This section covers using cert-manager to generate and manage Certificate Authorities (CAs) and configure k3k virtual clusters with custom certificate authorities.
+   * This section covers using cert-manager to generate and manage Certificate Authorities (CAs) and configure SUSE virtual clusters with custom certificate authorities.
 * Provisioning Virtual Clusters with Rancher Continuous Delivery [Prime-only]
    * /prime-docs/latest/en/suse-virtual-cluster/how-to-guides/provision-VC-with-fleet.html
    * This section covers deploying simple virtual clusters to one or multiple downstream clusters and defining environment-based deployment strategies across multiple clusters.


### PR DESCRIPTION
- Removed **Quick Start** guide from the DSC docs.
- Renamed the **VirtualClusterPolicy** guide in DSC to **VirtualClusterPolicy: Concepts**
- Renamed the **VirtualClusterPolicy** guide behind SCC to **VirtualClusterPolicy: Create policies**