### PR TITLE
Updating playbooks with CAPI v0.25 docs version

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: ../turtles-product-docs # en
       branches: [HEAD]
-      start_paths: [versions/latest, versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: ../k3k-product-docs # en
       branches: [HEAD]
       start_paths: [versions/latest]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -16,7 +16,7 @@ content:
       start_paths: [docs/*]
     - url: https://github.com/rancher/turtles-product-docs.git # en
       branches: [main]
-      start_paths: [versions/latest, versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
+      start_paths: [versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: https://github.com/rancher/k3k-product-docs.git # en
       branches: [main]
       start_paths: [versions/latest]


### PR DESCRIPTION
Depends on https://github.com/rancher/turtles-product-docs/pull/95