### PR TITLE
Remove v1.4 from start_paths

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -31,7 +31,7 @@ content:
       start_paths: [shared, docs/version*]
     - url: ../harvester-product-docs # en
       branches: [HEAD]
-      start_paths: [versions/v1.7, versions/v1.6, versions/v1.5, versions/v1.4]
+      start_paths: [versions/v1.7, versions/v1.6, versions/v1.5]
     - url: ../rancher-product-docs # en
       branches: [HEAD]
       start_paths: [versions/srfa]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -31,7 +31,7 @@ content:
       start_paths: [shared, docs/version*]
     - url: https://github.com/rancher/harvester-product-docs.git # en
       branches: [main]
-      start_paths: [versions/v1.7, versions/v1.6, versions/v1.5, versions/v1.4]
+      start_paths: [versions/v1.7, versions/v1.6, versions/v1.5]
     - url: https://github.com/rancher/rancher-product-docs.git # en
       branches: [main]
       start_paths: [versions/srfa]


### PR DESCRIPTION
According to the [Support Matrix](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-4-x/), all versions listed below have an EOL date of **27 November 2025**.

| Version | Released |
| --- | --- |
| 1.4.3 | 25 May 2025 |
| 1.4.2 | 11 March 2025 |
| 1.4.1 | 24 January 2025 |
| 1.4.0 | 27 November 2024 |