### PR TITLE
Add hardening guide path to articles-listing.conf

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -323,6 +323,9 @@ v1.3.0: 2024-03-15
 *  Add-Ons
    * /product-docs-playbook/virtualization/v1.6/en/add-ons/add-ons.html
    * Introduction to optional add-ons that extend functionality while maintaining a small installation footprint.
+*  Hardening Guide [Prime-only]
+   * /prime-docs/latest/en/suse-virtualization/hardening-guide/suse-virtualization-hardening.html
+   * Best practices for hardening standalone and Rancher-managed SUSE Virtualization clusters.
 *  Environment Variable for Rancher Agent Image Repository [Prime-only]
    * /prime-docs/latest/en/suse-virtualization/rancher-agent-image-repository.html
    * Instructions for specifying the correct registry so that SUSE Virtualization can retrieve the correct rancher-agent image.


### PR DESCRIPTION
Related `prime-docs` PRs: [#196](https://github.com/rancher/prime-docs/pull/196) and [#197](https://github.com/rancher/prime-docs/pull/197) (I merged both on Dec. 15.)

File location: [/suse-virtualization/hardening-guide/](https://github.com/rancher/prime-docs/tree/main/docs/latest/modules/en/pages/suse-virtualization/hardening-guide/)