### PR TITLE
Fix CI. k3k start_paths outdated

### DIFF
--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -19,7 +19,7 @@ content:
       start_paths: [versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: ../k3k-product-docs # en
       branches: [HEAD]
-      start_paths: [versions/latest]
+      start_paths: [versions/v*]
     - url: ../kubewarden-product-docs # en
       branches: [HEAD]
       start_paths: [shared, docs/version-*]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -19,7 +19,7 @@ content:
       start_paths: [versions/v0.25, versions/v0.24, versions/v0.23, versions/v0.22, versions/v0.21, versions/v0.20, versions/v0.19, versions/v0.18, versions/v0.17, versions/v0.16, versions/v0.15, versions/v0.14, versions/v0.13, versions/v0.12, versions/v0.11]
     - url: https://github.com/rancher/k3k-product-docs.git # en
       branches: [main]
-      start_paths: [versions/latest]
+      start_paths: [versions/v*]
     - url: https://github.com/rancher/kubewarden-product-docs.git # en
       branches: [main]
       start_paths: [shared, docs/version-*]


### PR DESCRIPTION
CI has been failing starting with [this build](https://github.com/rancher/product-docs-playbook/actions/runs/20923062134) at Jan 12, 6:32 AM PST.  Root cause looks to be https://github.com/rancher/k3k-product-docs/pull/92 where the file and version structure changed.