### PR TITLE
Update playbook files and article list for v1.8.1 release

### DIFF
--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -296,7 +296,7 @@ latest: 2025-11-18
    * Covers how to create and apply a VirtualClusterPolicy.
 -------------------------------
 SUSE® Virtualization
-v1.8.1: 2026-06-29
+v1.8.1: 2026-06-30
 v1.7.1: 2026-02-03
 v1.6.1: 2025-10-15
 v1.5.0: 2025-04-25

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -296,46 +296,50 @@ latest: 2025-11-18
    * Covers how to create and apply a VirtualClusterPolicy.
 -------------------------------
 SUSE® Virtualization
+v1.8.1: 2026-06-24
 v1.7.1: 2026-02-03
 v1.6.1: 2025-10-15
 v1.5.0: 2025-04-25
 v1.4.0: 2024-11-28
 v1.3.0: 2024-03-15
 *  Deploying a High-Availability Cluster
-   * /product-docs-playbook/virtualization/v1.7/en/introduction/deploy-ha-cluster.html
+   * /product-docs-playbook/virtualization/v1.8/en/introduction/deploy-ha-cluster.html
    * Steps for deploying a high-availability cluster and virtual machines that can host guest clusters and run custom workloads.
+*  High Availability Principles
+   * /product-docs-playbook/virtualization/v1.8/en/security-resilience/ha-principles.html
+   * How the control plane, virtualization, and distributed storage components deliver a resilient, highly available environment.
 *  Hardware and Network Requirements
-   * /product-docs-playbook/virtualization/v1.7/en/installation-setup/requirements.html
+   * /product-docs-playbook/virtualization/v1.8/en/installation-setup/requirements.html
    * Hardware and network requirements for installing SUSE Virtualization in test and production environments.
 *  Upgrades
-   * /product-docs-playbook/virtualization/v1.7/en/upgrades/upgrades.html
+   * /product-docs-playbook/virtualization/v1.8/en/upgrades/upgrades.html
    * Supported upgrade paths, prerequisites and procedures for both connected and air-gapped environments, and limitations.
 *  Host Management
-   * /product-docs-playbook/virtualization/v1.7/en/hosts/hosts.html
+   * /product-docs-playbook/virtualization/v1.8/en/hosts/hosts.html
    * Node maintenance, disk management, and node customization using a CloudInit resource.
 *  Virtual Machines
-   * /product-docs-playbook/virtualization/v1.7/en/virtual-machines/create-vm.html
+   * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/create-vm.html
    * Validated guest operating systems and methods for virtual machine creation.
 *  Virtual Machine Backup and Restore
-   * /product-docs-playbook/virtualization/v1.7/en/virtual-machines/backup-restore.html
+   * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/backup-restore.html
    * Steps for creating snapshots and backups, restoring virtual machines, and configuring space usage limits.
 *  Live Migration
-   * /product-docs-playbook/virtualization/v1.7/en/virtual-machines/live-migration.html
+   * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/live-migration.html
    * Prerequisites and mechanics of live migration, timeout details, and limitations.
 *  Creating a Volume
-   * /product-docs-playbook/virtualization/v1.7/en/storage/volumes/create-volume.html
+   * /product-docs-playbook/virtualization/v1.8/en/storage/volumes/create-volume.html
    * Steps for creating both empty volumes and volumes from virtual machine images using the UI, the API, and Terraform.
 *  Third-Party Storage Support
-   * /product-docs-playbook/virtualization/v1.7/en/storage/csidriver.html
-   * Scope of support, capabilities of validated CSI drivers, and steps for installing a CSI driver.
-*  Cluster Networks
-   * /product-docs-playbook/virtualization/v1.7/en/networking/cluster-network.html
+   * /product-docs-playbook/virtualization/v1.8/en/storage/csidriver.html
+   * Overview of built-in and third-party storage options.
+*  Cluster Network
+   * /product-docs-playbook/virtualization/v1.8/en/networking/cluster-network.html
    * Differences between the mgmt network and custom cluster networks, and steps for creating cluster networks and network configurations.
 *  SUSE Rancher Manager Integration
-   * /product-docs-playbook/virtualization/v1.7/en/integrations/rancher/rancher-integration.html
+   * /product-docs-playbook/virtualization/v1.8/en/integrations/rancher/rancher-integration.html
    * Overview of Rancher server deployment, SUSE Virtualization cluster import and management, and guest Kubernetes cluster provisioning.
 *  Add-Ons
-   * /product-docs-playbook/virtualization/v1.7/en/add-ons/add-ons.html
+   * /product-docs-playbook/virtualization/v1.8/en/add-ons/add-ons.html
    * Introduction to optional add-ons that extend functionality while maintaining a small installation footprint.
 *  Hardening Guide [Prime-only]
    * /prime-docs/latest/en/suse-virtualization/hardening-guide/suse-virtualization-hardening.html
@@ -343,9 +347,9 @@ v1.3.0: 2024-03-15
 *  Environment Variable for Rancher Agent Image Repository [Prime-only]
    * /prime-docs/latest/en/suse-virtualization/rancher-agent-image-repository.html
    * Instructions for specifying the correct registry so that SUSE Virtualization can retrieve the correct rancher-agent image.
-*  Creating MIG-backed vGPUs [Prime-only]
-   * /prime-docs/latest/en/suse-virtualization/creating-mig-backed-vgpu.html
-   * Steps for setting up MIG-backed vGPUs using the PCI Devices Controller and NVIDIA Driver Toolkit add-ons.
+*  SUSE VM Migration Toolkit [Prime-only]
+   * /prime-docs/latest/en/suse-virtualization/forklift-addon.html
+   * Steps for installing and using an add-on that facilitates migration of virtual machine workloads from VMware.
 -------------------------------
 SUSE® Rancher Manager
 2.14: 2026-04-30

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -329,9 +329,6 @@ v1.3.0: 2024-03-15
 *  Live Migration
    * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/live-migration.html
    * Prerequisites and mechanics of live migration, timeout details, and limitations.
-*  SUSE VM Migration Toolkit [Prime-only]
-   * /prime-docs/latest/en/suse-virtualization/forklift-addon.html
-   * Steps for installing and using an add-on that facilitates migration of virtual machine workloads from VMware.
 *  Storage
    * /product-docs-playbook/virtualization/v1.8/en/storage/storage.html
    * Overview of built-in and third-party storage options.
@@ -347,6 +344,9 @@ v1.3.0: 2024-03-15
 *  Add-Ons
    * /product-docs-playbook/virtualization/v1.8/en/add-ons/add-ons.html
    * Introduction to optional add-ons that extend functionality while maintaining a small installation footprint.
+*  SUSE VM Migration Toolkit [Prime-only]
+   * /prime-docs/latest/en/suse-virtualization/forklift-addon.html
+   * Steps for installing and using an add-on that facilitates migration of virtual machine workloads from VMware.
 *  SUSE Rancher Manager Integration
    * /product-docs-playbook/virtualization/v1.8/en/integrations/rancher/rancher-integration.html
    * Overview of Rancher server deployment, SUSE Virtualization cluster import and management, and guest Kubernetes cluster provisioning.

--- a/articles-listing.conf
+++ b/articles-listing.conf
@@ -296,12 +296,15 @@ latest: 2025-11-18
    * Covers how to create and apply a VirtualClusterPolicy.
 -------------------------------
 SUSE® Virtualization
-v1.8.1: 2026-06-24
+v1.8.1: 2026-06-29
 v1.7.1: 2026-02-03
 v1.6.1: 2025-10-15
 v1.5.0: 2025-04-25
 v1.4.0: 2024-11-28
 v1.3.0: 2024-03-15
+*  Overview
+   * /product-docs-playbook/virtualization/v1.8/en/introduction/overview.html
+   * High-level architecture and key features of SUSE Virtualization.
 *  Deploying a High-Availability Cluster
    * /product-docs-playbook/virtualization/v1.8/en/introduction/deploy-ha-cluster.html
    * Steps for deploying a high-availability cluster and virtual machines that can host guest clusters and run custom workloads.
@@ -310,7 +313,7 @@ v1.3.0: 2024-03-15
    * How the control plane, virtualization, and distributed storage components deliver a resilient, highly available environment.
 *  Hardware and Network Requirements
    * /product-docs-playbook/virtualization/v1.8/en/installation-setup/requirements.html
-   * Hardware and network requirements for installing SUSE Virtualization in test and production environments.
+   * Hardware and network requirements for installing SUSE Virtualization in testing and production environments.
 *  Upgrades
    * /product-docs-playbook/virtualization/v1.8/en/upgrades/upgrades.html
    * Supported upgrade paths, prerequisites and procedures for both connected and air-gapped environments, and limitations.
@@ -319,37 +322,40 @@ v1.3.0: 2024-03-15
    * Node maintenance, disk management, and node customization using a CloudInit resource.
 *  Virtual Machines
    * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/create-vm.html
-   * Validated guest operating systems and methods for virtual machine creation.
+   * Virtual machine creation methods and validated guest operating systems.
 *  Virtual Machine Backup and Restore
    * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/backup-restore.html
    * Steps for creating snapshots and backups, restoring virtual machines, and configuring space usage limits.
 *  Live Migration
    * /product-docs-playbook/virtualization/v1.8/en/virtual-machines/live-migration.html
    * Prerequisites and mechanics of live migration, timeout details, and limitations.
-*  Creating a Volume
-   * /product-docs-playbook/virtualization/v1.8/en/storage/volumes/create-volume.html
-   * Steps for creating both empty volumes and volumes from virtual machine images using the UI, the API, and Terraform.
-*  Third-Party Storage Support
-   * /product-docs-playbook/virtualization/v1.8/en/storage/csidriver.html
-   * Overview of built-in and third-party storage options.
-*  Cluster Network
-   * /product-docs-playbook/virtualization/v1.8/en/networking/cluster-network.html
-   * Differences between the mgmt network and custom cluster networks, and steps for creating cluster networks and network configurations.
-*  SUSE Rancher Manager Integration
-   * /product-docs-playbook/virtualization/v1.8/en/integrations/rancher/rancher-integration.html
-   * Overview of Rancher server deployment, SUSE Virtualization cluster import and management, and guest Kubernetes cluster provisioning.
-*  Add-Ons
-   * /product-docs-playbook/virtualization/v1.8/en/add-ons/add-ons.html
-   * Introduction to optional add-ons that extend functionality while maintaining a small installation footprint.
-*  Hardening Guide [Prime-only]
-   * /prime-docs/latest/en/suse-virtualization/hardening-guide/suse-virtualization-hardening.html
-   * Best practices for hardening standalone and Rancher-managed SUSE Virtualization clusters.
-*  Environment Variable for Rancher Agent Image Repository [Prime-only]
-   * /prime-docs/latest/en/suse-virtualization/rancher-agent-image-repository.html
-   * Instructions for specifying the correct registry so that SUSE Virtualization can retrieve the correct rancher-agent image.
 *  SUSE VM Migration Toolkit [Prime-only]
    * /prime-docs/latest/en/suse-virtualization/forklift-addon.html
    * Steps for installing and using an add-on that facilitates migration of virtual machine workloads from VMware.
+*  Storage
+   * /product-docs-playbook/virtualization/v1.8/en/storage/storage.html
+   * Overview of built-in and third-party storage options.
+*  Third-Party Storage Support
+   * /product-docs-playbook/virtualization/v1.8/en/storage/csidriver.html
+   * Scope of support, capabilities of validated CSI drivers, and steps for installing a CSI driver.
+*  Cluster Network
+   * /product-docs-playbook/virtualization/v1.8/en/networking/cluster-network.html
+   * Differences between the mgmt network and custom cluster networks, and steps for creating cluster networks and network configurations.
+*  Storage Network
+   * /product-docs-playbook/virtualization/v1.8/en/networking/storage-network.html
+   * Steps for configuring a dedicated storage network to isolate replication traffic from management and cluster workloads.
+*  Add-Ons
+   * /product-docs-playbook/virtualization/v1.8/en/add-ons/add-ons.html
+   * Introduction to optional add-ons that extend functionality while maintaining a small installation footprint.
+*  SUSE Rancher Manager Integration
+   * /product-docs-playbook/virtualization/v1.8/en/integrations/rancher/rancher-integration.html
+   * Overview of Rancher server deployment, SUSE Virtualization cluster import and management, and guest Kubernetes cluster provisioning.
+*  Environment Variable for Rancher Agent Image Repository [Prime-only]
+   * /prime-docs/latest/en/suse-virtualization/rancher-agent-image-repository.html
+   * Instructions for specifying the correct registry so that SUSE Virtualization can retrieve the correct rancher-agent image.
+*  Hardening Guide [Prime-only]
+   * /prime-docs/latest/en/suse-virtualization/hardening-guide/suse-virtualization-hardening.html
+   * Best practices for hardening standalone and Rancher-managed SUSE Virtualization clusters.
 -------------------------------
 SUSE® Rancher Manager
 2.14: 2026-04-30

--- a/product-docs-playbook-local.yml
+++ b/product-docs-playbook-local.yml
@@ -32,9 +32,9 @@ content:
     - url: ../longhorn-product-docs # en
       branches: [HEAD]
       start_paths: [shared, docs/version*]
-    - url: ../harvester-product-docs # en
+    - url: ../harvester-product-docs # en + de, es, fr, ja, pt, zh (v1.7 only)
       branches: [HEAD]
-      start_paths: [versions/v1.8, versions/v1.7, versions/v1.6, versions/v1.5]
+      start_paths: [versions/v*]
     - url: ../rancher-product-docs # en
       branches: [HEAD]
       start_paths: [versions/srfa]

--- a/product-docs-playbook-remote.yml
+++ b/product-docs-playbook-remote.yml
@@ -32,9 +32,9 @@ content:
     - url: https://github.com/rancher/longhorn-product-docs.git # en
       branches: [main]
       start_paths: [shared, docs/version*]
-    - url: https://github.com/rancher/harvester-product-docs.git # en
+    - url: https://github.com/rancher/harvester-product-docs.git # en + de, es, fr, ja, pt, zh (v1.7 only)
       branches: [main]
-      start_paths: [versions/v1.8, versions/v1.7, versions/v1.6, versions/v1.5]
+      start_paths: [versions/v*]
     - url: https://github.com/rancher/rancher-product-docs.git # en
       branches: [main]
       start_paths: [versions/srfa]


### PR DESCRIPTION
Release date: June 30, 2026

Changes:
- `articles-listing.conf`: Added the v1.8.1 release date; changed the version in existing URLs; added and replaced articles
- `product-docs-playbook-local.yml` & `product-docs-playbook-remote.yml`: Updated the `start_paths` value; updated the list of available languages
